### PR TITLE
Downgrade Tokio dependency to version 1.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "botcore"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 rust-version = "1.84.1"
 description = "Production-grade asynchronous bot engine with enterprise observability features"
@@ -22,7 +22,7 @@ categories = [
 anyhow = "1.0"
 async-trait = "0.1"
 tokio-stream = "0.1"
-tokio = { version = "1.41.1", features = ["full"] }
+tokio = { version = "1.14.1", features = ["full"] }
 tracing = "0.1"
 thiserror = "2.0.11"
 prometheus = { version = "0.13", optional = true }


### PR DESCRIPTION
- Revert Tokio runtime dependency to an earlier version
- Adjust Cargo.toml to use Tokio 1.14.1
- Bump package version to 1.0.3