### PR TITLE
Update GitHub Actions release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main # Or your default branch
 
+# Add this permissions block
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -16,7 +20,7 @@ jobs:
           fetch-depth: 0
           # Use a token with write access to push back the version commit/tag
           # You might need a Personal Access Token (PAT) if branch protection is strict
-          token: ${{ secrets.PAT_FOR_RELEASE || secrets.GITHUB_TOKEN }}
+          token: ${{  secrets.GITHUB_TOKEN }}
 
       - name: Setup Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -35,7 +39,7 @@ jobs:
       - name: Run cargo release (Patch Bump)
         env:
           # Token needed by cargo-release to push commit/tag
-          GITHUB_TOKEN: ${{ secrets.PAT_FOR_RELEASE || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Token needed for publishing to crates.io
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |


### PR DESCRIPTION
- Add permissions block to the `release.yml` workflow to allow write access to contents.
- Simplify token usage by directly referencing `secrets.GITHUB_TOKEN` for both fetching and publishing steps.